### PR TITLE
rename reject argv to avoid collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Options:
           [default: 0]
   -f, --filter <REGEX>
           A regular expression used to filter keys while scanning. Keys that do not match will be skipped before any subsequent operations are performed
-  -r, --reject <REGEX>
+  -s, --reject <REGEX>
           A regular expression used to reject or skip keys while scanning. Keys that match will be skipped before any subsequent operations are performed
       --min-refresh-delay <NUMBER>
           Set a minimum refresh delay between progress bar updates, in milliseconds.

--- a/src/argv.rs
+++ b/src/argv.rs
@@ -75,7 +75,7 @@ pub struct Argv {
   pub filter:    Option<String>,
   /// A regular expression used to reject or skip keys while scanning. Keys that match will be skipped before
   /// any subsequent operations are performed.
-  #[arg(short = 'r', long = "reject", value_name = "REGEX")]
+  #[arg(short = 's', long = "reject", value_name = "REGEX")]
   pub reject:    Option<String>,
 
   /// Set a minimum refresh delay between progress bar updates, in milliseconds.


### PR DESCRIPTION
`-r` is already a short arg for replicas, so clap crashes the scanner when you try to run it. (The last 2 versions have been broken in this way actually)
Open to suggestions for alternatives besides `s` (I was thinking "skip").