### PR TITLE
fix: actually save sum output to file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_scanner"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Alec Embke <aembke@gmail.com>"]

--- a/src/argv.rs
+++ b/src/argv.rs
@@ -125,6 +125,7 @@ impl Argv {
       Commands::Memory(ref argv) => argv.file.clone(),
       Commands::Idle(ref argv) => argv.file.clone(),
       Commands::Ttl(ref argv) => argv.file.clone(),
+      Commands::Sum(ref argv) => argv.file.clone(),
       _ => None,
     }
   }


### PR DESCRIPTION
Previously you could specify a file but it wouldn't actually save anywhere